### PR TITLE
Typo error master-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ]
     , "require": {
-        "cakephp/utility": "master-dev"
+        "cakephp/utility": "dev-master"
         , "guzzlehttp/guzzle": "4.*"
         , "guzzlehttp/guzzle-services": "0.3.*"
-        , "sabre/xml" : "master-dev"
+        , "sabre/xml" : "dev-master"
     }
     , "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
…ages

  Problem 1
    - Installation request for jadb/groovehq dev-master -> satisfiable by jadb/groovehq[dev-master].
    - jadb/groovehq dev-master requires cakephp/utility master-dev -> no matching package found.

Seems like a typo
