### PR TITLE
Add method for listing agents

### DIFF
--- a/src/Service/AgentsDescription.php
+++ b/src/Service/AgentsDescription.php
@@ -9,6 +9,19 @@ class AgentsDescription extends BasicServiceDescription
     {
         return [
             'operations' => [
+                'list' => [
+                    'summary' => 'Listing agents',
+                    'httpMethod' => 'GET',
+                    'uri' => '/agents',
+                    'parameters' => [
+                        'group' => [
+                            'description' => 'The ID of a Group to filter by',
+                            'type' => 'string',
+                            'required' => false,
+                            'location' => 'query'
+                        ]
+                    ],
+                ],
                 'find' => [
                     'summary' => 'Finding one agent',
                     'httpMethod' => 'GET',

--- a/tests/Service/AgentsDescriptionTest.php
+++ b/tests/Service/AgentsDescriptionTest.php
@@ -13,8 +13,12 @@ class AgentsDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $operations = $agents->getOperations();
 
-        $expected = ['find'];
+        $expected = ['list', 'find'];
         $result = array_keys($operations);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['group', 'access_token'];
+        $result = array_keys($operations['list']['parameters']);
         $this->assertEquals($expected, $result);
 
         $expected = ['agent_email', 'access_token'];


### PR DESCRIPTION
Groove API has an endpoint for listing all agents which can be included into the API Client.
