### PR TITLE
Add missing methods to API client

### DIFF
--- a/src/Service/GroupsDescription.php
+++ b/src/Service/GroupsDescription.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GrooveHQ\Service;
+
+class GroupsDescription extends BasicServiceDescription
+{
+
+    protected function getServiceDescription()
+    {
+        return [
+            'operations' => [
+                'groups' => [
+                    'summary' => 'Listing groups',
+                    'httpMethod' => 'GET',
+                    'uri' => '/groups',
+                    'parameters' => [],
+                ],
+            ]
+        ];
+    }
+
+}

--- a/src/Service/MailboxesDescription.php
+++ b/src/Service/MailboxesDescription.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GrooveHQ\Service;
+
+class MailboxesDescription extends BasicServiceDescription
+{
+
+    protected function getServiceDescription()
+    {
+        return [
+            'operations' => [
+                'mailboxes' => [
+                    'summary' => 'Listing mailboxes',
+                    'httpMethod' => 'GET',
+                    'uri' => '/mailboxes',
+                    'parameters' => [],
+                ],
+                'folders' => [
+                    'summary' => 'Listing mailboxes',
+                    'httpMethod' => 'GET',
+                    'uri' => '/mailboxes',
+                    'parameters' => [
+                        'mailbox' => [
+                            'description' => 'The ID or email address of a Mailbox to filter by',
+                            'type' => 'string',
+                            'required' => false,
+                            'location' => 'query'
+                        ],
+                    ],
+                ]
+            ]
+        ];
+    }
+
+}

--- a/src/Service/MailboxesDescription.php
+++ b/src/Service/MailboxesDescription.php
@@ -18,7 +18,7 @@ class MailboxesDescription extends BasicServiceDescription
                 'folders' => [
                     'summary' => 'Listing mailboxes',
                     'httpMethod' => 'GET',
-                    'uri' => '/mailboxes',
+                    'uri' => '/folders',
                     'parameters' => [
                         'mailbox' => [
                             'description' => 'The ID or email address of a Mailbox to filter by',

--- a/src/Service/MessagesDescription.php
+++ b/src/Service/MessagesDescription.php
@@ -71,6 +71,19 @@ class MessagesDescription extends BasicServiceDescription
                         ],
                     ]
                 ],
+                'attachments' => [
+                    'summary' => 'Listing attachments',
+                    'httpMethod' => 'GET',
+                    'uri' => '/attachments',
+                    'parameters' => [
+                        'message' => [
+                            'description' => 'The ID of the message to list attachments for',
+                            'type' => 'string',
+                            'required' => true,
+                            'location' => 'query'
+                        ],
+                    ],
+                ],
             ]
         ];
     }

--- a/src/Service/TicketsDescription.php
+++ b/src/Service/TicketsDescription.php
@@ -111,10 +111,35 @@ class TicketsDescription extends BasicServiceDescription
                         ],
                     ],
                 ],
+                'count' => [
+                    'summary' => 'Listing ticket counts',
+                    'httpMethod' => 'GET',
+                    'uri' => 'tickets/count',
+                    'parameters' => [
+                        'mailbox' => [
+                            'description' => 'The email or ID of a mailbox to filter by',
+                            'type' => 'string',
+                            'required' => false,
+                            'location' => 'query',
+                        ],
+                    ],
+                ],
                 'find' => [
                     'summary' => 'Finding one ticket',
                     'httpMethod' => 'GET',
                     'uri' => '/tickets/{ticket_number}',
+                    'parameters' => [
+                        'ticket_number' => [
+                            'description' => 'The ticket number',
+                            'type' => 'number',
+                            'location' => 'uri',
+                        ],
+                    ]
+                ],
+                'assignee' => [
+                    'summary' => 'Finding a ticket\'s assignee',
+                    'httpMethod' => 'GET',
+                    'uri' => '/tickets/{ticket_number}/assignee',
                     'parameters' => [
                         'ticket_number' => [
                             'description' => 'The ticket number',

--- a/tests/Service/GroupsDescriptionTest.php
+++ b/tests/Service/GroupsDescriptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace GrooveHQ\Test\Service;
+
+use GrooveHQ\Service\GroupsDescription;
+
+class GroupsDescriptionTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testGroupsDescription()
+    {
+        $messages = new GroupsDescription(['token' => 'someToken']);
+
+        $operations = $messages->getOperations();
+
+        $expected = ['groups'];
+        $result = array_keys($operations);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['access_token'];
+        $result = array_keys($operations['groups']['parameters']);
+        $this->assertEquals($expected, $result);
+    }
+
+}

--- a/tests/Service/MailboxesDescriptionTest.php
+++ b/tests/Service/MailboxesDescriptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace GrooveHQ\Test\Service;
+
+use GrooveHQ\Service\MailboxesDescription;
+
+class MailboxesDescriptionTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testMailboxesDescription()
+    {
+        $messages = new MailboxesDescription(['token' => 'someToken']);
+
+        $operations = $messages->getOperations();
+
+        $expected = ['mailboxes', 'folders'];
+        $result = array_keys($operations);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['access_token'];
+        $result = array_keys($operations['mailboxes']['parameters']);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['mailbox', 'access_token'];
+        $result = array_keys($operations['folders']['parameters']);
+        $this->assertEquals($expected, $result);
+    }
+
+}

--- a/tests/Service/MessagesDescriptionTest.php
+++ b/tests/Service/MessagesDescriptionTest.php
@@ -13,7 +13,7 @@ class MessagesDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $operations = $messages->getOperations();
 
-        $expected = ['list', 'find', 'create'];
+        $expected = ['list', 'find', 'create', 'attachments'];
         $result = array_keys($operations);
         $this->assertEquals($expected, $result);
 
@@ -27,6 +27,10 @@ class MessagesDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $expected = ['ticket_number', 'body', 'note', 'access_token'];
         $result = array_keys($operations['create']['parameters']);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['message', 'access_token'];
+        $result = array_keys($operations['attachments']['parameters']);
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/Service/TicketsDescriptionTest.php
+++ b/tests/Service/TicketsDescriptionTest.php
@@ -13,7 +13,7 @@ class TicketsDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $operations = $tickets->getOperations();
 
-        $expected = ['create', 'list', 'find', 'state', 'update'];
+        $expected = ['create', 'list', 'count', 'find', 'assignee', 'state', 'update'];
         $result = array_keys($operations);
         $this->assertEquals($expected, $result);
 
@@ -25,8 +25,16 @@ class TicketsDescriptionTest extends \PHPUnit_Framework_TestCase
         $result = array_keys($operations['list']['parameters']);
         $this->assertEquals($expected, $result);
 
+        $expected = ['mailbox', 'access_token'];
+        $result = array_keys($operations['count']['parameters']);
+        $this->assertEquals($expected, $result);
+
         $expected = ['ticket_number', 'access_token'];
         $result = array_keys($operations['find']['parameters']);
+        $this->assertEquals($expected, $result);
+
+        $expected = ['ticket_number', 'access_token'];
+        $result = array_keys($operations['assignee']['parameters']);
         $this->assertEquals($expected, $result);
 
         $expected = ['ticket_number', 'access_token'];


### PR DESCRIPTION
There were a number of methods missing for mailboxes, folders, groups, attachments and tickets that can be included into the API client. I've tested these new methods using our API key and can confirm each operation returns a valid response.
